### PR TITLE
Update table.length, fix doc bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.vscode/settings.json
+
+# Ignores all files/directories not within src/SFramework
+# This allows you to create any necessary test files/folders at the root of SFramework
+# without affecting the repo
+src/*
+!src/SFramework

--- a/docs/API/Components/SpriteRenderer.md
+++ b/docs/API/Components/SpriteRenderer.md
@@ -49,7 +49,7 @@ Sets the animation of the SpriteRenderer to the given spritesheet Font asset
 self.gameObject.spriteRenderer:SetAnimation(CS.FindAsset("Sprites/Sample/Animations/Idle", "Font"))
 ```
 
-## SpriteRenderer:SetAnimatinFrameDuration
+## SpriteRenderer:SetAnimationFrameDuration
 Sets the animation's frame duration of the SpriteRenderer to the given number of game ticks.  Keep in mind that there are 60 ticks per second in CraftStudio.  So for instance, if you want to play an animation at 5 frames per second then you would divide 60 by 5 to get the number of ticks.  The default frame duration is 5 ticks.
 ### Arguments
 - `ticks` - `number` (required) the number of game ticks per frame of the animation

--- a/docs/API/LUA_Library_Extensions/table.md
+++ b/docs/API/LUA_Library_Extensions/table.md
@@ -20,7 +20,7 @@ local index = table.indexOf(myTable, 4) --should return 3
 ```
 
 ## table.length
-Returns the length of the given table
+Returns the length of the given table.  This is an alias for `table.getn`
 ### Arguments
 - `t` - `table` (required) the table to get the length of
 ### Example

--- a/src/SFramework/LUA Extensions/table.lua
+++ b/src/SFramework/LUA Extensions/table.lua
@@ -30,9 +30,5 @@ end
     @return the length of the table
 ]]--
 function table.length(t)
-    local count = 0
-    for k,v in pairs(t) do
-        count = count + 1
-    end
-    return count
+    return table.getn(t)
 end


### PR DESCRIPTION
Updates `table.length` to just be an alias of `table.getn`, as I was previously unaware that `table.getn` was a thing.

Fixes a doc bug where an anchor was misspelled.