### PR TITLE
fix bug in table.length

### DIFF
--- a/docs/API/LUA_Library_Extensions/table.md
+++ b/docs/API/LUA_Library_Extensions/table.md
@@ -20,11 +20,14 @@ local index = table.indexOf(myTable, 4) --should return 3
 ```
 
 ## table.length
-Returns the length of the given table.  This is an alias for `table.getn`
+Returns the length of the given table.  This will work for both arrays and keyed tables
 ### Arguments
 - `t` - `table` (required) the table to get the length of
 ### Example
 ```lua
-local myTable = {2, 5, 4, 7, 1}
-local length = table.length(myTable) --should return 5
+local myArrayTable = {2, 5, 4, 7, 1}
+local arrayLength = table.length(myArrayTable) --should return 5
+
+local myKeyedTable = {x = 1, y = 2}
+local tableLength = table.length(myKeyedTable) --should return 2
 ```

--- a/src/SFramework/LUA Extensions/table.lua
+++ b/src/SFramework/LUA Extensions/table.lua
@@ -30,5 +30,12 @@ end
     @return the length of the table
 ]]--
 function table.length(t)
-    return table.getn(t)
+    local len = #t
+    if len ~= 0 then
+        return len
+    end
+    for k,v in pairs(t) do
+        len = len + 1
+    end
+    return len
 end


### PR DESCRIPTION
Using `table.length` as an alias for `table.getn` only works for array tables.  I need to support both.  For efficiency, start by attempting to get length using `#t`, which will return 0 if not an array.  In the case that `#t` is 0, perform the less efficient loop to calculate the length.