### PR TITLE
#6: Create Vector2 Class

### DIFF
--- a/docs/API/CS_API_Extensions/README.md
+++ b/docs/API/CS_API_Extensions/README.md
@@ -3,3 +3,4 @@ SFramework extends upon some of the capability built into CraftStudio. Here, you
 
 # Contents
 - [GameObject](GameObject.md)
+- [Vector2](Vector2.md)

--- a/docs/API/CS_API_Extensions/Vector2.md
+++ b/docs/API/CS_API_Extensions/Vector2.md
@@ -1,0 +1,34 @@
+# Vector2
+SFramework provides a more 2D-intuitive way of using the native `Vector3` class.  Everything you can do with a `Vector3` in CraftStudio, you can also do with a `Vector2`, as it is simply an alias for `Vector3`.  `Vector2` provides just a couple of overrides that make sense in a 2D context, which you can find information on here.  For documentation on `Vector3` functions, you can find it on the CraftStudio wiki [here](https://elisee.github.io/craftstudio-wiki/Reference/Scripting/Math/Vector3.html).
+
+# Contents
+- [Vector2](#Vector2)
+  - [New](#vector2new)
+  - [Forward](#vector2forward)
+  - [UnitZ](#vector2unitz)
+
+# Vector2
+
+## Vector2:New
+Syntactic sugar for the `Vector3:New()` function.  Returns a Vector3 with Z value 0
+### Example
+```lua
+local myVector2 = Vector2:New(1, 2)
+print(myVector2) -- prints {x=1, y=2, z=0}
+```
+
+## Vector2:Forward
+Overrides `Vector3:Forward()` to error every time.  This is because we don't want to worry about anyting on the Z axis when using a Vector2
+### Example
+```lua
+-- this will spit an error out in the game log
+local myVector2 = Vector2:Forward()
+```
+
+## Vector2:UnitZ
+Overrides `Vector3:UnitZ()` to error every time.  This is because we don't want to worry about anyting on the Z axis when using a Vector2
+### Example
+```lua
+-- this will spit an error out in the game log
+local myVector2 = Vector2:UnitZ()
+```

--- a/docs/API/CS_API_Extensions/Vector2.md
+++ b/docs/API/CS_API_Extensions/Vector2.md
@@ -11,10 +11,16 @@ SFramework provides a more 2D-intuitive way of using the native `Vector3` class.
 
 ## Vector2:New
 Syntactic sugar for the `Vector3:New()` function.  Returns a Vector3 with Z value 0
+### Arguments
+- `x` - `number` the X value of the vector (also the Y value if it is the only argument)
+- `y` - `number` (optional) the Y value of the vector
 ### Example
 ```lua
-local myVector2 = Vector2:New(1, 2)
-print(myVector2) -- prints {x=1, y=2, z=0}
+local myTwoArgVector2 = Vector2:New(1, 2)
+print(myTwoArgVector2) -- prints {x=1, y=2, z=0}
+
+local myOneArgVector2 = Vector2:New(1)
+print(myOneArgVector2) -- prints {x=1, y=1, z=0}
 ```
 
 ## Vector2:Forward

--- a/docs/API/README.md
+++ b/docs/API/README.md
@@ -5,6 +5,7 @@ Here you'll find information about SFramework's API.
 - [SFramework](SFramework.md)
 - [CS API Extensions](CS_API_Extensions)
   - [GameObject](CS_API_Extensions/GameObject.md)
+  - [Vector2](CS_API_Extensions/Vector2.md)
 - [Components](Components)
   - [SpriteRenderer](Components/SpriteRenderer.md)
   - [Physics](Components/Physics.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Here, you can find all the information you need on how to use SFramework as well
   - [SFramework](API/SFramework.md)
   - [CS API Extensions](API/CS_API_Extensions)
     - [GameObject](API/CS_API_Extensions/GameObject.md)
+    - [Vector2](API/CS_API_Extensions/Vector2.md)
   - [Components](API/Components)
     - [SpriteRenderer](API/Components/SpriteRenderer.md)
     - [Physics](API/Components/Physics.md)

--- a/src/SFramework/CS API Extensions/Vector2.lua
+++ b/src/SFramework/CS API Extensions/Vector2.lua
@@ -1,0 +1,30 @@
+Vector2 = {}
+Vector2.__index = Vector3
+setmetatable(Vector2, Vector3)
+
+--[[
+    Vector2 constructor
+    
+    This will gracefully create the Vector3 equivalent of the Vector2
+    
+    @return the Vector3 representation
+]]--
+function Vector2:New(x, y)
+    return Vector3:New(x, y, 0)
+end
+
+--[[
+    Overrides Vector3:Forward() to error on all calls
+    Vector2 only cares about X and Y axes so this is irrelevant
+]]--
+function Vector2:Forward()
+    error("Vector2 does not care about the Z axis")
+end
+
+--[[
+    Overrides Vector3:UnitZ() to error on all calls
+    Vector2 only cares about X and Y axes so this is irrelevant
+]]--
+function Vector2:UnitZ()
+    error("Vector2 does not care about the Z axis")
+end

--- a/src/SFramework/CS API Extensions/Vector2.lua
+++ b/src/SFramework/CS API Extensions/Vector2.lua
@@ -10,7 +10,7 @@ setmetatable(Vector2, Vector3)
     @return the Vector3 representation
 ]]--
 function Vector2:New(x, y)
-    return Vector3:New(x, y, 0)
+    return Vector3:New(x, y or x, 0)
 end
 
 --[[


### PR DESCRIPTION
## Additions
- Adds the `Vector2` class
  - this is simply an alias for `Vector3`, with some minor changes to the constructor and some methods, which will make it more intuitive for the 2D context that SFramework is aimed at
  - `Vector2:New()` will take both 1 and 2 args
  - `Vector2:Forward()` will error every call
  - `Vector2:UnitZ()` will error every call
  - Closes #6 
- Update doc for new `Vector2` class